### PR TITLE
[Fix] RTC crash on boot/wake

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -765,7 +765,7 @@
 			<key>DisableLinkeditJettison</key>
 			<true/>
 			<key>DisableRtcChecksum</key>
-			<false/>
+			<true/>
 			<key>ExtendBTFeatureFlags</key>
 			<false/>
 			<key>ExternalDiskIcons</key>
@@ -928,7 +928,7 @@
 			<key>4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102</key>
 			<dict>
 				<key>rtc-blacklist</key>
-				<data></data>
+				<data>WFk=</data>
 			</dict>
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<dict>


### PR DESCRIPTION
This fixes the unexpected shutdowns/CMOS safe mode error whenever AppleRTC tries to write into an invalid memory space. This blocks regions `0x58` and `0x59` as suggested in this [guide](https://dortania.github.io/OpenCore-Post-Install/misc/rtc.html). 

A combination of `DisableRtcChecksum` and using `rtc-blacklist` is necessary to prevent these crashes. 

![image](https://user-images.githubusercontent.com/11053683/103468210-bbcf0480-4d24-11eb-994e-32a76012cb8f.png)
